### PR TITLE
LibreJS support

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,6 +252,8 @@
       <div class="container">
         <div class="row">
           <a href="https://github.com/philippgitpush/bunnymuralhelper" target="_blank">philippgitpush/bunnymuralhelper</a>
+          <p></p>
+          <a href="/javascript.html" data-jslicense="1">JavaScript license information</a>
         </div>
       </div>
     </div>

--- a/javascript.html
+++ b/javascript.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>javascript license information</title>
+</head>
+
+<h1>License Information for javascript files used in this website</h1>
+
+
+<table id="jslicense-labels1">
+    <tr>
+        <td><a href="/js/main.js">/js/main.js</a></td>
+        <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+        <td><a href="/js/main.js">/js/main.js</a></td>
+    </tr>
+    <tr>
+        <td><a href="/js/fireflies.js">/js/fireflies.js</a></td>
+        <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+        <td><a href="/js/fireflies.js">/js/fireflies.js</a></td>
+    </tr>
+</table>


### PR DESCRIPTION
I have added a javascript web labels file listing the license information of the
javascript files used in the site and linked to it on the main page

this is needed for LibreJS support, a browser extension used to run only free
javascript

I have not added license information for the umami script.js as I was not able
to find an unminified version of the file, which is something LibreJS wants 
